### PR TITLE
Add audio loading utilities and ffprobe wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ Los presets se validan con pydantic (schema_version=1). Ejecuta:
 python -m app.core.preset_manager
 ```
 para generar dos presets de ejemplo en `app/assets/presets/` y probar la carga/validación.
+
+## Audio IO
+- `load_audio(path)` carga WAV/MP3/OGG como float32 en el SR nativo y devuelve `(data[ch,n], sr, info)` usando librosa.
+- `normalize_sr(data, sr, target=44100, mono='mix')` reajusta el SR con librosa y maneja canales.
+- `peak_normalize(data, peak)` normaliza por pico.
+- `run_ffprobe(path)` + `parse_audio_info()` obtienen metadatos del audio.
+- `aac_passthrough_ok(info, target_sr, target_channels)` indica si es viable el **passthrough AAC** (MVP: requiere AAC y 44.1 kHz).
+
+Notas:
+- FFmpeg/ffprobe puede resolverse desde `app/ffmpeg/` o el PATH del sistema.

--- a/app/core/analysis.py
+++ b/app/core/analysis.py
@@ -1,21 +1,61 @@
 from __future__ import annotations
-
 from pathlib import Path
-from typing import Tuple
-
-import librosa
+from typing import Tuple, Optional
 import numpy as np
+import librosa
+
+from .media_probe import run_ffprobe, parse_audio_info, is_aac_lc_passthrough_possible, AudioInfo
 
 
-def load_audio(path: str | Path) -> Tuple[np.ndarray, int]:
-    """Loads audio file returning waveform and sample rate."""
-    data, sample_rate = librosa.load(Path(path), sr=None, mono=True)
-    return data, sample_rate
+def load_audio(path: str | Path) -> tuple[np.ndarray, int, AudioInfo]:
+    """Carga WAV/MP3/OGG a float32 [-1,1], mantiene SR y canales nativos; retorna (audio, sr, info)."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(p)
+    # librosa usa audioread/ffmpeg para MP3/OGG si es necesario
+    y, sr = librosa.load(str(p), sr=None, mono=False)  # shape: (n,) o (ch, n)
+    if y.ndim == 1:
+        y = y[None, :]  # (1, n) para consistencia
+    y = y.astype(np.float32, copy=False)
+    # Probe con ffprobe para metadatos y passthrough
+    try:
+        ffp = run_ffprobe(p)
+        info = parse_audio_info(ffp)
+    except Exception:
+        info = AudioInfo()
+        info.sample_rate = int(sr)
+        info.channels = int(y.shape[0])
+        info.codec_name = ""
+    return y, int(sr), info
 
 
-def normalize_sr(data: np.ndarray, sample_rate: int, target: int = 44_100) -> Tuple[np.ndarray, int]:
-    """Normalizes audio to target sample rate."""
-    if sample_rate == target:
-        return data, sample_rate
-    resampled = librosa.resample(data, orig_sr=sample_rate, target_sr=target)
-    return resampled, target
+def normalize_sr(data: np.ndarray, sr: int, target: int = 44100, mono: Optional[str] = "mix") -> tuple[np.ndarray, int]:
+    """Resample a target SR; maneja canales: mono='keep'|'mix'|'left'.
+    - data: (ch, n)
+    - retorna (data_resampled, target)
+    """
+    if data.ndim != 2:
+        raise ValueError("Expected shape (ch, n)")
+    ch, n = data.shape
+    out = []
+    for c in range(ch):
+        out.append(librosa.resample(y=data[c], orig_sr=sr, target_sr=target))
+    res = np.stack(out, axis=0)
+    if mono == "mix":
+        res = np.mean(res, axis=0, keepdims=True)
+    elif mono == "left":
+        res = res[:1, :]
+    elif mono == "keep":
+        pass
+    else:
+        raise ValueError("mono must be one of 'mix','left','keep'")
+    return res.astype(np.float32, copy=False), target
+
+
+def peak_normalize(data: np.ndarray, peak: float = 0.98) -> np.ndarray:
+    m = np.max(np.abs(data)) + 1e-12
+    return (data / m * peak).astype(np.float32, copy=False)
+
+
+def aac_passthrough_ok(info: AudioInfo, target_sr: int = 44100, target_channels: int | None = 2) -> bool:
+    return is_aac_lc_passthrough_possible(info, target_sr=target_sr, target_channels=target_channels)

--- a/app/core/media_probe.py
+++ b/app/core/media_probe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import shutil
+import subprocess
+from typing import Optional, Dict, Any
+
+
+def _ffbin_candidates(name: str) -> list[str]:
+    """Devuelve candidatos de ruta para ffmpeg/ffprobe (embebido o del sistema)."""
+    here = Path(__file__).resolve()
+    root = here.parents[2]  # .../app/
+    embedded = root / "ffmpeg" / (name + (".exe" if __import__('platform').system() == "Windows" else ""))
+    return [str(embedded), name]
+
+
+def run_ffprobe(path: str | Path) -> Dict[str, Any]:
+    """Ejecuta ffprobe -v error -print_format json -show_streams -show_format y retorna el dict JSON."""
+    src = str(path)
+    cmd = ["-v", "error", "-print_format", "json", "-show_streams", "-show_format", src]
+    last_err = None
+    for bin_name in ("ffprobe",):
+        for cand in _ffbin_candidates(bin_name):
+            exe = shutil.which(cand) if not Path(cand).exists() else str(cand)
+            if not exe:
+                continue
+            try:
+                out = subprocess.check_output([exe, *cmd], stderr=subprocess.STDOUT)
+                return json.loads(out.decode("utf-8", errors="ignore"))
+            except subprocess.CalledProcessError as e:
+                last_err = e
+                continue
+    raise RuntimeError(f"ffprobe not found or failed to run: {last_err}")
+
+
+@dataclass
+class AudioInfo:
+    codec_name: str = ""
+    sample_rate: int = 0
+    channels: int = 0
+    channel_layout: str = ""
+    duration: float = 0.0
+    format_name: str = ""
+
+
+def parse_audio_info(ffp: Dict[str, Any]) -> AudioInfo:
+    streams = ffp.get("streams", [])
+    fmt = ffp.get("format", {})
+    a = AudioInfo()
+    for s in streams:
+        if s.get("codec_type") == "audio":
+            a.codec_name = s.get("codec_name", "") or ""
+            try:
+                a.sample_rate = int(s.get("sample_rate") or 0)
+            except Exception:
+                a.sample_rate = 0
+            a.channels = int(s.get("channels") or 0)
+            a.channel_layout = s.get("channel_layout", "") or ""
+            break
+    a.duration = float(fmt.get("duration") or 0.0)
+    a.format_name = fmt.get("format_name", "") or ""
+    return a
+
+
+def is_aac_lc_passthrough_possible(info: AudioInfo, target_sr: int = 44100, target_channels: int | None = None) -> bool:
+    """Regla MVP: passthrough si codec es 'aac' (perfil LC asumido) y sample_rate == target_sr y canales coinciden (si se especifica)."""
+    if info.codec_name.lower() != "aac":
+        return False
+    if info.sample_rate != target_sr:
+        return False
+    if target_channels is not None and info.channels and info.channels != target_channels:
+        return False
+    return True

--- a/app/tests/test_analysis.py
+++ b/app/tests/test_analysis.py
@@ -1,0 +1,29 @@
+import numpy as np
+from app.core.analysis import normalize_sr, peak_normalize, aac_passthrough_ok
+from app.core.media_probe import AudioInfo
+
+
+def test_resample_and_mono_mix():
+    sr = 48000
+    t = np.linspace(0, 1.0, int(sr), endpoint=False)
+    # Señal estéreo simple (izq=sin, der=sin*0.5)
+    left = 0.5 * np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    right = 0.25 * np.sin(2 * np.pi * 880 * t).astype(np.float32)
+    data = np.stack([left, right], axis=0)
+    out, sr2 = normalize_sr(data, sr, target=44100, mono="mix")
+    assert sr2 == 44100
+    assert out.ndim == 2 and out.shape[0] == 1  # mezclado a mono
+    assert np.isfinite(out).all()
+
+
+def test_peak_normalize():
+    x = np.array([[0.1, -0.5, 0.25]], dtype=np.float32)
+    y = peak_normalize(x, peak=0.9)
+    assert np.isclose(np.max(np.abs(y)), 0.9, atol=1e-3)
+
+
+def test_aac_passthrough_rule():
+    info = AudioInfo(codec_name="aac", sample_rate=44100, channels=2)
+    assert aac_passthrough_ok(info, target_sr=44100, target_channels=2) is True
+    info2 = AudioInfo(codec_name="aac", sample_rate=48000, channels=2)
+    assert aac_passthrough_ok(info2, target_sr=44100, target_channels=2) is False


### PR DESCRIPTION
## Summary
- add ffprobe wrapper and AAC passthrough helper in `media_probe`
- implement robust audio loading, resampling, and normalization utilities
- add unit tests and update README with Audio IO usage notes

## Testing
- pytest app/tests/test_analysis.py *(fails: missing numpy/librosa dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de907a85d48320932f1b7370cd8659